### PR TITLE
fix: avoid variable shadowing in generated validator

### DIFF
--- a/src/__tests__/output/ComplexExample.valiator.ts
+++ b/src/__tests__/output/ComplexExample.valiator.ts
@@ -115,7 +115,11 @@ export function validateKoaRequest(
     `Schema#/definitions/${typeName}/properties/query`,
   );
   const body = ajv.getSchema(`Schema#/definitions/${typeName}/properties/body`);
-  const validate = (prop: string, validator: any, ctx: Context): any => {
+  const validateProperty = (
+    prop: string,
+    validator: any,
+    ctx: Context,
+  ): any => {
     const data = (ctx as any)[prop];
     if (validator) {
       const valid = validator(data);
@@ -134,9 +138,9 @@ export function validateKoaRequest(
   };
   return ctx => {
     return {
-      params: validate('params', params, ctx),
-      query: validate('query', query, ctx),
-      body: validate('body', body, ctx),
+      params: validateProperty('params', params, ctx),
+      query: validateProperty('query', query, ctx),
+      body: validateProperty('body', body, ctx),
     };
   };
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -98,7 +98,7 @@ export const VALIDATE_KOA_REQUEST_IMPLEMENTATION = `export function validateKoaR
   const params = ajv.getSchema(\`Schema#/definitions/\${typeName}/properties/params\`);
   const query = ajv.getSchema(\`Schema#/definitions/\${typeName}/properties/query\`);
   const body = ajv.getSchema(\`Schema#/definitions/\${typeName}/properties/body\`);
-  const validate = (
+  const validateProperty = (
     prop: string,
     validator: any,
     ctx: Context,
@@ -118,9 +118,9 @@ export const VALIDATE_KOA_REQUEST_IMPLEMENTATION = `export function validateKoaR
   };
   return (ctx) => {
     return {
-      params: validate('params', params, ctx),
-      query: validate('query', query, ctx),
-      body: validate('body', body, ctx),
+      params: validateProperty('params', params, ctx),
+      query: validateProperty('query', query, ctx),
+      body: validateProperty('body', body, ctx),
     }
   };
 }`;


### PR DESCRIPTION
This can fix an issue with projects that run tslint on the generated code.