### PR TITLE
fix: get koa request body from correct prop

### DIFF
--- a/src/__tests__/output/ComplexExample.valiator.ts
+++ b/src/__tests__/output/ComplexExample.valiator.ts
@@ -120,7 +120,10 @@ export function validateKoaRequest(
     validator: any,
     ctx: Context,
   ): any => {
-    const data = (ctx as any)[prop];
+    const data =
+      prop === 'body'
+        ? ctx.request && (ctx.request as any).body
+        : (ctx as any)[prop];
     if (validator) {
       const valid = validator(data);
 

--- a/src/__tests__/printValidator.test.ts
+++ b/src/__tests__/printValidator.test.ts
@@ -46,9 +46,11 @@ test('validateRequest', () => {
       id: 0,
       value: 'hello',
     },
-    body: {
-      id: 1,
-      value: '2019-01-25T19:09:28.179Z',
+    request: {
+      body: {
+        id: 1,
+        value: '2019-01-25T19:09:28.179Z',
+      },
     },
     throw: (number: number, message: string) => {
       throw new Error(`${number} <KOA ERROR> ${message}`);

--- a/src/template.ts
+++ b/src/template.ts
@@ -103,7 +103,7 @@ export const VALIDATE_KOA_REQUEST_IMPLEMENTATION = `export function validateKoaR
     validator: any,
     ctx: Context,
   ): any => {
-    const data = (ctx as any)[prop];
+    const data = prop === 'body' ? ctx.request && (ctx.request as any).body : (ctx as any)[prop];
     if (validator) {
       const valid = validator(data);
   


### PR DESCRIPTION
BREAKING CHANGE: if you were passing something that looked like a koa request, we now get the `body` from `ctx.request.body`