### PR TITLE
fix: disable composite before running ts

### DIFF
--- a/src/loadTsConfig.ts
+++ b/src/loadTsConfig.ts
@@ -12,5 +12,9 @@ export default function loadTsConfig(cwd: string): any {
     // we need to disable it if experimentalDecorators support is off
     compilerOptions.emitDecoratorMetadata = false;
   }
+  if (compilerOptions.composite) {
+    // the composite setting adds a few constraints that cause us all manner of problems
+    compilerOptions.composite = false;
+  }
   return compilerOptions;
 }


### PR DESCRIPTION
The "composite" flag requires that all files are included in the dependencies, which isn't always true for us as we explicitly select the files we're interested in.