### PR TITLE
type-only import and export

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -23,9 +23,9 @@ export const DECLARE_KOA_CONTEXT = `export interface KoaContext {
 }`;
 
 export const importNamedTypes = (names: string[], relativePath: string) =>
-  `import {${names.join(', ')}} from '${relativePath}';`;
+  `import type {${names.join(', ')}} from '${relativePath}';`;
 export const importDefaultType = (name: string, relativePath: string) =>
-  `import ${name} from '${relativePath}';`;
+  `import type ${name} from '${relativePath}';`;
 export const importType = (
   name: string,
   relativePath: string,
@@ -45,7 +45,7 @@ export const declareAJV = (options: Ajv.Options) =>
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
 `;
 
-export const exportNamed = (names: string[]) => `export {${names.join(', ')}};`;
+export const exportNamed = (names: string[]) => `export type {${names.join(', ')}};`;
 
 export const declareSchema = (name: string, schema: TJS.Definition) =>
   `export const ${name} = ${stringify(schema, {space: 2})};`;


### PR DESCRIPTION
This pull request includes changes to the `src/template.ts` file to ensure that type-only imports and exports are used in TypeScript. This helps to optimize the code and avoid potential issues with unnecessary imports.

TypeScript improvements:

* Changed `importNamedTypes` function to use `import type` for named imports.
* Changed `importDefaultType` function to use `import type` for default imports.
* Changed `exportNamed` function to use `export type` for named exports.